### PR TITLE
feat: add monitoring instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ The output from the market place UI is fed directly to the ARM template. You can
     </td></tr>
 
   <tr><td>chronograf</td><td>string</td>
-    <td>Either <code>Yes</code> or <code>No</code> to provision an add-on instance with a public IP on port :8888 that has the Chronograf application installed.
-    This can also be used as a jumpbox to connect and manage other virtual machines on the internal network.
+    <td>Either <code>Yes</code> or <code>No</code> to provision an add-on instance with a public IP on port <code>:8888</code> that has the Chronograf application installed. This can also be used as a jumpbox to connect and manage other virtual machines on the internal network.
     </td></tr>
 
   <tr><td>monitor</td><td>string</td>

--- a/README.md
+++ b/README.md
@@ -25,8 +25,13 @@ The output from the market place UI is fed directly to the ARM template. You can
     </td></tr>
 
   <tr><td>chronograf</td><td>string</td>
-    <td>Either <code>Yes</code> or <code>No</code> provision an extra machine with a public IP tha thas Chronograf installed on it.
+    <td>Either <code>Yes</code> or <code>No</code> to provision an add-on instance with a public IP on port :8888 that has the Chronograf application installed.
     This can also be used as a jumpbox to connect and manage other virtual machines on the internal network.
+    </td></tr>
+
+  <tr><td>monitor</td><td>string</td>
+    <td>Either <code>Yes</code> or <code>No</code> to provision an add-on instance with InfluxDB OSS service installed for monitoring 
+    the enterprise cluster. Selecting this option will also configure and enable Telegraf services on all enterpise instances.
     </td></tr>
 
   <tr><td>vmSizeDataNodes</td><td>string</td>

--- a/deploy.sh
+++ b/deploy.sh
@@ -23,9 +23,9 @@ if ! (az group show --name "${resource_group}"); then
 fi
 
 # Accept the legal terms for the influxdata offer skus (only needs ti be run once for your sunscritopn ID)
-if ! (az vm image terms show --urn influxdata:influxdb-enterprise-vm:data:1.7.10 --query "accepted"); then
-      az vm image terms accept --urn influxdata:influxdb-enterprise-vm:data:1.7.10
-      az vm image terms accept --urn influxdata:influxdb-enterprise-vm:meta:1.7.10
+if ! (az vm image terms show --urn influxdata:influxdb-enterprise-vm:data:latest --query "accepted"); then
+      az vm image terms accept --urn influxdata:influxdb-enterprise-vm:data:latest
+      az vm image terms accept --urn influxdata:influxdb-enterprise-vm:meta:latest
 fi
 
 az deployment group create \

--- a/parameters/password.parameters.json
+++ b/parameters/password.parameters.json
@@ -8,6 +8,9 @@
     "chronograf": {
         "value": "Yes"
     },
+    "monitor": {
+        "value": "No"
+    },
     "vmSizeDataNodes": {
         "value": "Standard_DS2_v2"
     },
@@ -22,9 +25,9 @@
     },
     "password": {
         "value": {
-            "password": null,
-            "sshPublicKey": "ssh-rsa <redacted>",
-            "authenticationType": "sshPublicKey"
+            "password": "changeMe!4",
+            "sshPublicKey": null,
+            "authenticationType": "password"
         }
     },
     "adminUsername": {

--- a/parameters/password.parameters.json
+++ b/parameters/password.parameters.json
@@ -22,9 +22,9 @@
     },
     "password": {
         "value": {
-            "password": "changeMe!4",
-            "sshPublicKey": null,
-            "authenticationType": "password"
+            "password": null,
+            "sshPublicKey": "ssh-rsa <redacted>",
+            "authenticationType": "sshPublicKey"
         }
     },
     "adminUsername": {

--- a/parameters/ssh.parameters.json
+++ b/parameters/ssh.parameters.json
@@ -8,6 +8,9 @@
     "chronograf": {
         "value": "Yes"
     },
+    "monitor": {
+        "value": "No"
+    },
     "vmSizeDataNodes": {
         "value": "Standard_DS2_v2"
     },

--- a/src/createUiDefinition.json
+++ b/src/createUiDefinition.json
@@ -56,7 +56,9 @@
                         "label": "Database admin username",
                         "toolTip": "Initial username for InfluxDB admin user.",
                         "constraints": {
-                            "required": true
+                            "required": true,
+                            "validationMessage": "Username must not be a reserved word."
+
                         }
                     },
                     {

--- a/src/createUiDefinition.json
+++ b/src/createUiDefinition.json
@@ -57,6 +57,7 @@
                         "toolTip": "Initial username for InfluxDB admin user.",
                         "constraints": {
                             "required": true,
+                            "regex": "^(?!(?:password)$)\\w+$",
                             "validationMessage": "Username must not be a reserved word."
 
                         }
@@ -215,24 +216,50 @@
             },
             {
                 "name": "externalAccessStep",
-                "label": "External Access & Chronograf",
+                "label": "External Access & Add-ons",
                 "subLabel": {
                     "preValidation": "Required",
                     "postValidation": "Done"
                 },
-                "bladeTitle": "External Access & Chronograf",
+                "bladeTitle": "External Access & Add-ons",
                 "elements": [
                     {
                         "name": "chronografSection",
                         "type": "Microsoft.Common.Section",
-                        "label": "Chronograf",
+                        "label": "Add Chronograf",
                         "elements": [
                             {
                                 "name": "chronograf",
                                 "type": "Microsoft.Common.OptionsGroup",
-                                "label": "Install Chronograf?",
+                                "label": "Install Chronograf service",
                                 "defaultValue": "No",
-                                "toolTip": "Yes, to provision a single Chronograf instance.",
+                                "toolTip": "Yes, to provision a single Chronograf instance on port :8888",
+                                "constraints": {
+                                    "allowedValues": [
+                                        {
+                                            "label": "Yes",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "label": "No",
+                                            "value": "No"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "monitorSection",
+                        "type": "Microsoft.Common.Section",
+                        "label": "Add Monitoring",
+                        "elements": [
+                            {
+                                "name": "monitor",
+                                "type": "Microsoft.Common.OptionsGroup",
+                                "label": "Install InfluxDB service",
+                                "defaultValue": "No",
+                                "toolTip": "Yes, to provision a single InfluxDB-OSS instance for monitoring your enterpise cluster. This will also configure and enable Telegraf services on all enterpise nodes",
                                 "constraints": {
                                     "allowedValues": [
                                         {
@@ -258,7 +285,7 @@
                                 "type": "Microsoft.Common.OptionsGroup",
                                 "label": "Load balancer type",
                                 "defaultValue": "Internal",
-                                "toolTip": "Choose whether the load balancer should be public facing (external) or internal.",
+                                "toolTip": "Choose whether the load balancer should be external facing or internal.",
                                 "constraints": {
                                     "allowedValues": [
                                         {
@@ -280,6 +307,7 @@
         "outputs": {
             "loadBalancerType": "[steps('externalAccessStep').externalAccessSection.loadBalancerType]",
             "chronograf": "[steps('externalAccessStep').chronografSection.chronograf]",
+            "monitor": "[steps('externalAccessStep').monitorSection.monitor]",
             "vmSizeDataNodes": "[steps('clusterConfig').vmSizeDataNodes]",
             "vmDataDiskSize": "[steps('clusterConfig').vmDataDiskSize]",
             "vmDataNodeCount": "[steps('clusterConfig').vmDataNodeCount]",

--- a/src/machines/chronograf-resources.json
+++ b/src/machines/chronograf-resources.json
@@ -33,15 +33,6 @@
                 "description": "Administrator password used when provisioning virtual machines"
             }
         },
-        "influxTags": {
-            "type": "object",
-            "defaultValue": {
-                "provider": "influxdata"
-            },
-            "metadata": {
-                "description": "Unique identifiers to allow the Azure Infrastructure to understand the origin of resources deployed to Azure. You do not need to supply a value for this."
-            }
-        },
         "osSettings": {
             "type": "object",
             "metadata": {
@@ -152,7 +143,7 @@
             "name": "[variables('vmName')]",
             "location": "[parameters('location')]",
             "tags": {
-                "provider": "[toUpper(parameters('influxTags').provider)]"
+                "provider": "[parameters('osSettings').influxTags.provider]"
             },
             "dependsOn": [
                 "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"

--- a/src/machines/chronograf-resources.json
+++ b/src/machines/chronograf-resources.json
@@ -15,12 +15,6 @@
                 "description": "Location where resources will be provisioned"
             }
         },
-        "subnet": {
-            "type": "object",
-            "metadata": {
-                "description": "Subnet object for provisioning resources in (expects properties name as the subnet name, and vnet as the virtual network name on the object)"
-            }
-        },
         "adminUsername": {
             "type": "string",
             "metadata": {
@@ -33,6 +27,12 @@
                 "description": "Administrator password used when provisioning virtual machines"
             }
         },
+        "networkSettings": {
+            "type": "object",
+            "metadata": {
+                "description": "Network settings to deploy on"
+            }
+        },
         "osSettings": {
             "type": "object",
             "metadata": {
@@ -41,14 +41,14 @@
         }
     },
     "variables": {
-        "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('subnet').vnet, parameters('subnet').name)]",
+        "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('networkSettings').subnet.data.vnet, parameters('networkSettings').subnet.data.name)]",
         "vmName": "[concat('vm', parameters('namespace'))]",
         "publicIpName": "[concat('pip-', parameters('namespace'))]",
         "securityGroupName": "[concat('nsg-', parameters('namespace'))]",
         "nicName": "[concat('nic-0-vm', parameters('namespace'))]",
         "linuxConfiguration": {
             "disablePasswordAuthentication": "true",
-             "ssh": {
+            "ssh": {
                 "publicKeys": [
                     {
                         "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
@@ -150,7 +150,7 @@
             ],
             "properties": {
                 "hardwareProfile": {
-                    "vmSize":  "[parameters('osSettings').chronoSize]"
+                    "vmSize": "[parameters('osSettings').chronoSize]"
                 },
                 "osProfile": {
                     "computerName": "[variables('vmName')]",
@@ -192,5 +192,10 @@
             ]
         }
     ],
-    "outputs": {}
+    "outputs": {
+        "resourceID": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIpName'))]"
+        }
+    }
 }

--- a/src/machines/chronograf-resources.json
+++ b/src/machines/chronograf-resources.json
@@ -4,7 +4,6 @@
     "parameters": {
         "namespace": {
             "type": "string",
-            "defaultValue": "chronograf",
             "metadata": {
                 "description": "The namespace prefix for resources created by this template"
             }
@@ -71,8 +70,8 @@
                         "properties": {
                             "description": "Allow inbound SSH traffic from anyone",
                             "protocol": "Tcp",
-                            "sourcePortRange": "[parameters('osSettings').managementPort]",
-                            "destinationPortRange": "[parameters('osSettings').managementPort]",
+                            "sourcePortRange": "[parameters('networkSettings').managementPort]",
+                            "destinationPortRange": "[parameters('networkSettings').managementPort]",
                             "sourceAddressPrefix": "*",
                             "destinationAddressPrefix": "*",
                             "access": "Allow",
@@ -150,7 +149,7 @@
             ],
             "properties": {
                 "hardwareProfile": {
-                    "vmSize": "[parameters('osSettings').chronoSize]"
+                    "vmSize": "[parameters('osSettings').vmDefaultSize]"
                 },
                 "osProfile": {
                     "computerName": "[variables('vmName')]",

--- a/src/machines/datanodes-resources.json
+++ b/src/machines/datanodes-resources.json
@@ -33,12 +33,6 @@
                 "description": "Size of the InfluxEnterprise data nodes"
             }
         },
-        "platformFaultDomainCount": {
-            "type": "int",
-            "metadata": {
-                "description": "Number of Fault Domains"
-            }
-        },
         "vmCount": {
             "type": "int",
             "defaultValue": 2,
@@ -93,7 +87,7 @@
             "location": "[parameters('location')]",
             "properties": {
                 "platformUpdateDomainCount": 10,
-                "platformFaultDomainCount": "[parameters('platformFaultDomainCount')]"
+                "platformFaultDomainCount": "[parameters('networkSettings').platformFaultDomainCount]"
             },
             "sku": {
                 "name": "Aligned"

--- a/src/machines/datanodes-resources.json
+++ b/src/machines/datanodes-resources.json
@@ -101,8 +101,8 @@
             "name": "[concat('avail-', parameters('namespace'))]",
             "location": "[parameters('location')]",
             "properties": {
-                "platformUpdateDomainCount": 20,
-                "platformFaultDomainCount": 3
+                "platformUpdateDomainCount": 8,
+                "platformFaultDomainCount": 2
             },
             "sku": {
                 "name": "Aligned"

--- a/src/machines/datanodes-resources.json
+++ b/src/machines/datanodes-resources.json
@@ -26,18 +26,6 @@
                 "description": "Location where resources will be provisioned"
             }
         },
-        "subnet": {
-            "type": "object",
-            "metadata": {
-                "description": "The name of the subnet to deploy resources into"
-            }
-        },
-        "dataNodesIpPrefix": {
-            "type": "string",
-            "metadata": {
-                "description": "IP Prefix used to append index for static addresses"
-            }
-        },
         "vmSize": {
             "type": "string",
             "defaultValue": "Standard_A1",
@@ -64,6 +52,12 @@
                 "description": "OS settings to deploy on"
             }
         },
+        "networkSettings": {
+            "type": "object",
+            "metadata": {
+                "description": "OS settings to deploy on"
+            }
+        },
         "namespace": {
             "type": "string",
             "metadata": {
@@ -78,7 +72,7 @@
         }
     },
     "variables": {
-        "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('subnet').vnet, parameters('subnet').name)]",
+        "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('networkSettings').subnet.data.vnet, parameters('networkSettings').subnet.data.name)]",
         "linuxConfiguration": {
             "disablePasswordAuthentication": "true",
             "ssh": {
@@ -120,7 +114,7 @@
                         "name": "ipconfig1",
                         "properties": {
                             "privateIPAllocationMethod": "Static",
-                            "privateIPAddress": "[concat(parameters('dataNodesIpPrefix'),copyindex())]",
+                            "privateIPAddress": "[concat(parameters('networkSettings').dataNodesIpPrefix,copyindex())]",
                             "subnet": {
                                 "id": "[variables('subnetRef')]"
                             },

--- a/src/machines/datanodes-resources.json
+++ b/src/machines/datanodes-resources.json
@@ -101,7 +101,7 @@
             "name": "[concat('avail-', parameters('namespace'))]",
             "location": "[parameters('location')]",
             "properties": {
-                "platformUpdateDomainCount": 8,
+                "platformUpdateDomainCount": 10,
                 "platformFaultDomainCount": 2
             },
             "sku": {

--- a/src/machines/datanodes-resources.json
+++ b/src/machines/datanodes-resources.json
@@ -26,15 +26,6 @@
                 "description": "Location where resources will be provisioned"
             }
         },
-        "influxTags": {
-            "type": "object",
-            "defaultValue": {
-                "provider": "influxdata"
-            },
-            "metadata": {
-                "description": "Unique identifiers to allow the Azure Infrastructure to understand the origin of resources deployed to Azure. You do not need to supply a value for this."
-            }
-        },
         "subnet": {
             "type": "object",
             "metadata": {
@@ -52,6 +43,12 @@
             "defaultValue": "Standard_A1",
             "metadata": {
                 "description": "Size of the InfluxEnterprise data nodes"
+            }
+        },
+        "platformFaultDomainCount": {
+            "type": "int",
+            "metadata": {
+                "description": "Number of Fault Domains"
             }
         },
         "vmCount": {
@@ -84,7 +81,7 @@
         "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('subnet').vnet, parameters('subnet').name)]",
         "linuxConfiguration": {
             "disablePasswordAuthentication": "true",
-             "ssh": {
+            "ssh": {
                 "publicKeys": [
                     {
                         "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
@@ -102,7 +99,7 @@
             "location": "[parameters('location')]",
             "properties": {
                 "platformUpdateDomainCount": 10,
-                "platformFaultDomainCount": 2
+                "platformFaultDomainCount": "[parameters('platformFaultDomainCount')]"
             },
             "sku": {
                 "name": "Aligned"
@@ -139,7 +136,7 @@
             "name": "[concat('vm', parameters('namespace'), '-', copyindex())]",
             "location": "[parameters('location')]",
             "tags": {
-                "provider": "[toUpper(parameters('influxTags').provider)]"
+                "provider": "[parameters('osSettings').influxTags.provider]"
             },
             "plan": {
                 "name": "data",
@@ -217,5 +214,6 @@
             ]
         }
     ],
-    "outputs": {}
+    "outputs": {
+    }
 }

--- a/src/machines/datanodes-resources.json
+++ b/src/machines/datanodes-resources.json
@@ -26,20 +26,6 @@
                 "description": "Location where resources will be provisioned"
             }
         },
-        "vmSize": {
-            "type": "string",
-            "defaultValue": "Standard_A1",
-            "metadata": {
-                "description": "Size of the InfluxEnterprise data nodes"
-            }
-        },
-        "vmCount": {
-            "type": "int",
-            "defaultValue": 2,
-            "metadata": {
-                "description": "Number of InfluxEnterpirse data nodes"
-            }
-        },
         "osSettings": {
             "type": "object",
             "metadata": {
@@ -100,7 +86,7 @@
             "location": "[parameters('location')]",
             "copy": {
                 "name": "[concat('dataNodeNic','nicLoop')]",
-                "count": "[parameters('vmCount')]"
+                "count": "[parameters('osSettings').vmDataNodeCount]"
             },
             "properties": {
                 "ipConfigurations": [
@@ -133,7 +119,7 @@
             },
             "copy": {
                 "name": "[concat(parameters('namespace'), 'virtualMachineLoop')]",
-                "count": "[parameters('vmCount')]"
+                "count": "[parameters('osSettings').vmDataNodeCount]"
             },
             "dependsOn": [
                 "[concat('Microsoft.Network/networkInterfaces/', 'nic-', copyindex(), '-vm', parameters('namespace'), '-', copyindex())]",
@@ -144,7 +130,7 @@
                     "id": "[resourceId('Microsoft.Compute/availabilitySets', concat('avail-', parameters('namespace')))]"
                 },
                 "hardwareProfile": {
-                    "vmSize": "[parameters('vmSize')]"
+                    "vmSize":  "[parameters('osSettings').vmSizeDataNodes]"
                 },
                 "osProfile": {
                     "computerName": "[concat('vm', parameters('namespace'), '-', copyindex())]",
@@ -202,6 +188,5 @@
             ]
         }
     ],
-    "outputs": {
-    }
+    "outputs": {}
 }

--- a/src/machines/metanodes-resources.json
+++ b/src/machines/metanodes-resources.json
@@ -20,15 +20,6 @@
                 "description": "Location where resources will be provisioned"
             }
         },
-        "influxTags": {
-            "type": "object",
-            "defaultValue": {
-                "provider": "influxdata"
-            },
-            "metadata": {
-                "description": "Unique identifiers to allow the Azure Infrastructure to understand the origin of resources deployed to Azure. You do not need to supply a value for this."
-            }
-        },
         "namespace": {
             "type": "string",
             "metadata": {
@@ -45,6 +36,12 @@
             "type": "string",
             "metadata": {
                 "description": "IP Prefix used to append index for static addresses"
+            }
+        },
+        "platformFaultDomainCount": {
+            "type": "int",
+            "metadata": {
+                "description": "Number of Fault Domains"
             }
         },
         "vmSize": {
@@ -83,7 +80,7 @@
             "location": "[parameters('location')]",
             "properties": {
                 "platformUpdateDomainCount": 3,
-                "platformFaultDomainCount": 2
+                "platformFaultDomainCount": "[parameters('platformFaultDomainCount')]"
             },
             "sku": {
                 "name": "Aligned"
@@ -119,7 +116,7 @@
             "name": "[concat('vm', parameters('namespace'), '-', copyindex(1))]",
             "location": "[parameters('location')]",
             "tags": {
-                "provider": "[toUpper(parameters('influxTags').provider)]"
+                "provider": "[parameters('osSettings').influxTags.provider]"
             },
             "plan": {
                 "name": "meta",
@@ -202,7 +199,7 @@
             "name": "[concat('vm', parameters('namespace'), '-0')]",
             "location": "[parameters('location')]",
             "tags": {
-                "provider": "[toUpper(parameters('influxTags').provider)]"
+                "provider": "[parameters('osSettings').influxTags.provider]"
             },
             "plan": {
                 "name": "meta",

--- a/src/machines/metanodes-resources.json
+++ b/src/machines/metanodes-resources.json
@@ -26,12 +26,6 @@
                 "description": "The namespace for resources created by this template"
             }
         },
-        "platformFaultDomainCount": {
-            "type": "int",
-            "metadata": {
-                "description": "Number of Fault Domains"
-            }
-        },
         "vmSize": {
             "type": "string",
             "defaultValue": "Standard_A0",
@@ -74,7 +68,7 @@
             "location": "[parameters('location')]",
             "properties": {
                 "platformUpdateDomainCount": 3,
-                "platformFaultDomainCount": "[parameters('platformFaultDomainCount')]"
+                "platformFaultDomainCount": "[parameters('networkSettings').platformFaultDomainCount]"
             },
             "sku": {
                 "name": "Aligned"

--- a/src/machines/metanodes-resources.json
+++ b/src/machines/metanodes-resources.json
@@ -26,12 +26,6 @@
                 "description": "The namespace for resources created by this template"
             }
         },
-        "subnet": {
-            "type": "object",
-            "metadata": {
-                "description": "The VNET and Subnet to deploy the nodes in to"
-            }
-        },
         "platformFaultDomainCount": {
             "type": "int",
             "metadata": {

--- a/src/machines/metanodes-resources.json
+++ b/src/machines/metanodes-resources.json
@@ -32,12 +32,6 @@
                 "description": "The VNET and Subnet to deploy the nodes in to"
             }
         },
-        "metaNodesIpPrefix": {
-            "type": "string",
-            "metadata": {
-                "description": "IP Prefix used to append index for static addresses"
-            }
-        },
         "platformFaultDomainCount": {
             "type": "int",
             "metadata": {
@@ -51,6 +45,12 @@
                 "description": "Size of the InfluxEnterprise meta nodes"
             }
         },
+        "networkSettings": {
+            "type": "object",
+            "metadata": {
+                "description": "OS settings to deploy on"
+            }
+        },
         "osSettings": {
             "type": "object",
             "metadata": {
@@ -59,7 +59,7 @@
         }
     },
     "variables": {
-        "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('subnet').vnet, parameters('subnet').name)]",
+        "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('networkSettings').subnet.meta.vnet, parameters('networkSettings').subnet.meta.name)]",
         "linuxConfiguration": {
             "disablePasswordAuthentication": "true",
              "ssh": {
@@ -101,7 +101,7 @@
                         "name": "ipconfig1",
                         "properties": {
                             "privateIPAllocationMethod": "Static",
-                            "privateIPAddress": "[concat(parameters('metaNodesIpPrefix'), copyindex())]",
+                            "privateIPAddress": "[concat(parameters('networkSettings').metaNodesIpPrefix, copyindex())]",
                             "subnet": {
                                 "id": "[variables('subnetRef')]"
                             }

--- a/src/machines/metanodes-resources.json
+++ b/src/machines/metanodes-resources.json
@@ -26,13 +26,6 @@
                 "description": "The namespace for resources created by this template"
             }
         },
-        "vmSize": {
-            "type": "string",
-            "defaultValue": "Standard_A0",
-            "metadata": {
-                "description": "Size of the InfluxEnterprise meta nodes"
-            }
-        },
         "networkSettings": {
             "type": "object",
             "metadata": {
@@ -124,7 +117,7 @@
                     "id": "[resourceId('Microsoft.Compute/availabilitySets', concat('avail-', parameters('namespace')))]"
                 },
                 "hardwareProfile": {
-                    "vmSize": "[parameters('vmSize')]"
+                    "vmSize": "[parameters('osSettings').vmSizeMetaNodes]"
                 },
                 "osProfile": {
                     "computerName":  "[concat('vm', parameters('namespace'), '-', copyindex(1))]",
@@ -205,7 +198,7 @@
                     "id": "[resourceId('Microsoft.Compute/availabilitySets', concat('avail-', parameters('namespace')))]"
                 },
                 "hardwareProfile": {
-                    "vmSize": "[parameters('vmSize')]"
+                    "vmSize": "[parameters('osSettings').vmSizeDataNodes]"
                 },
                 "osProfile": {
                     "computerName":  "[concat('vm', parameters('namespace'), '-0')]",

--- a/src/machines/metanodes-resources.json
+++ b/src/machines/metanodes-resources.json
@@ -198,7 +198,7 @@
                     "id": "[resourceId('Microsoft.Compute/availabilitySets', concat('avail-', parameters('namespace')))]"
                 },
                 "hardwareProfile": {
-                    "vmSize": "[parameters('osSettings').vmSizeDataNodes]"
+                    "vmSize": "[parameters('osSettings').vmSizeMetaNodes]"
                 },
                 "osProfile": {
                     "computerName":  "[concat('vm', parameters('namespace'), '-0')]",
@@ -245,13 +245,13 @@
             "resources": [
                 {
                     "type": "Microsoft.Compute/virtualMachines/extensions",
-                    "name": "[concat('vm', parameters('namespace'),'-0', '/configureMaster0')]",
+                    "name": "[concat('vm', parameters('namespace'),'-0', '/configureLeader0')]",
                     "apiVersion": "2019-07-01",
                     "location": "[parameters('location')]",
                     "dependsOn": [
                         "[concat('Microsoft.Compute/virtualMachines/', 'vm', parameters('namespace'),'-0')]"
                     ],
-                    "properties": "[parameters('osSettings').extensionSettings.master]"
+                    "properties": "[parameters('osSettings').extensionSettings.leader]"
                 }
             ]
         }

--- a/src/machines/metanodes-resources.json
+++ b/src/machines/metanodes-resources.json
@@ -83,7 +83,7 @@
             "location": "[parameters('location')]",
             "properties": {
                 "platformUpdateDomainCount": 3,
-                "platformFaultDomainCount": 3
+                "platformFaultDomainCount": 2
             },
             "sku": {
                 "name": "Aligned"

--- a/src/machines/monitor-resources.json
+++ b/src/machines/monitor-resources.json
@@ -1,0 +1,135 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "adminUsername": {
+            "type": "string",
+            "metadata": {
+                "description": "Admin username used when provisioning virtual machines"
+            }
+        },
+        "password": {
+            "type": "object",
+            "metadata": {
+                "description": "Admin password used when provisioning virtual machines"
+            }
+        },
+        "location": {
+            "type": "string",
+            "metadata": {
+                "description": "Location where resources will be provisioned"
+            }
+        },
+        "namespace": {
+            "type": "string",
+            "metadata": {
+                "description": "The namespace for resources created by this template"
+            }
+        },
+        "networkSettings": {
+            "type": "object",
+            "metadata": {
+                "description": "OS settings to deploy on"
+            }
+        },
+        "osSettings": {
+            "type": "object",
+            "metadata": {
+                "description": "InfluxEnterprise deployment platform settings"
+            }
+        }
+    },
+    "variables": {
+        "nicName": "[concat('nic-0-vm', parameters('namespace'))]",
+        "vmName": "[concat('vm', parameters('namespace'))]",
+        "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('networkSettings').subnet.data.vnet, parameters('networkSettings').subnet.data.name)]",
+        "linuxConfiguration": {
+            "disablePasswordAuthentication": "true",
+             "ssh": {
+                "publicKeys": [
+                    {
+                        "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+                        "keyData": "[parameters('password').sshPublicKey]"
+                    }
+                ]
+            }
+        }
+    },
+    "resources": [
+        {
+            "apiVersion": "2019-04-01",
+            "type": "Microsoft.Network/networkInterfaces",
+            "name": "[variables('nicName')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "privateIPAddress": "[parameters('networkSettings').dataNodesIpPrefix]",
+                            "subnet": {
+                                "id": "[variables('subnetRef')]"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "2019-07-01",
+            "type": "Microsoft.Compute/virtualMachines",
+            "name": "[variables('vmName')]",
+            "location": "[parameters('location')]",
+            "tags": {
+                "provider": "[parameters('osSettings').influxTags.provider]"
+            },
+            "dependsOn": [
+                "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+            ],
+            "properties": {
+                "hardwareProfile": {
+                    "vmSize": "[parameters('osSettings').vmDefaultSize]"
+                },
+                "osProfile": {
+                    "computerName": "[variables('vmName')]",
+                    "adminUsername": "[parameters('adminUsername')]",
+                    "adminPassword": "[if(equals(parameters('password').authenticationType,'password'),parameters('password').password,json('null'))]",
+                    "linuxConfiguration": "[if(equals(parameters('password').authenticationType, 'password'), json('null'), variables('linuxConfiguration'))]"
+                },
+                "storageProfile": {
+                    "imageReference": "[parameters('osSettings').imageReference]",
+                    "osDisk": {
+                        "name": "[concat(variables('vmName'), '-osdisk')]",
+                        "createOption": "FromImage",
+                        "diskSizeGB": 32,
+                        "managedDisk": {
+                            "storageAccountType": "Standard_LRS"
+                        },
+                        "osType": "Linux"
+                    }
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
+                        }
+                    ]
+                }
+            },
+            "resources": [
+                {
+                    "type": "Microsoft.Compute/virtualMachines/extensions",
+                    "name": "[concat(variables('vmName'),'/installMonitor')]",
+                    "apiVersion": "2019-07-01",
+                    "location": "[parameters('location')]",
+                    "dependsOn": [
+                        "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"
+                    ],
+                    "properties": "[parameters('osSettings').extensionSettings.monitor]"
+                }
+            ]
+        }
+    ],
+    "outputs": {}
+}

--- a/src/mainTemplate.json
+++ b/src/mainTemplate.json
@@ -270,8 +270,8 @@
                 "platformFaultDomainCount": 3
             }
         },
-        "platformFaultDomainCount": "[if(contains(variables('locations'), variables('location')), variables('locations')[variables('location')].platformFaultDomainCount, 2)]",
         "networkSettings": {
+            "platformFaultDomainCount": "[if(contains(variables('locations'), variables('location')), variables('locations')[variables('location')].platformFaultDomainCount, 2)]",
             "metaNodesIpPrefix": "10.0.0.1",
             "dataNodesIpPrefix": "10.0.1.1",
             "virtualNetworkName": "[parameters('virtualNetworkName')]",
@@ -346,20 +346,17 @@
                     "password": {
                         "value": "[variables('password')]"
                     },
-                    "networkSettings": {
-                        "value": "[variables('networkSettings')]"
-                    },
                     "location": {
                         "value": "[variables('location')]"
-                    },
-                    "platformFaultDomainCount": {
-                        "value": "[variables('platformFaultDomainCount')]"
                     },
                     "vmSize": {
                         "value": "[parameters('vmSizeMetaNodes')]"
                     },
                     "namespace": {
                         "value": "meta"
+                    },
+                    "networkSettings": {
+                        "value": "[variables('networkSettings')]"
                     },
                     "osSettings": {
                         "value": "[variables('osSettings')]"
@@ -416,12 +413,6 @@
                     "location": {
                         "value": "[variables('location')]"
                     },
-                    "networkSettings": {
-                        "value": "[variables('networkSettings')]"
-                    },
-                    "platformFaultDomainCount": {
-                        "value": "[variables('platformFaultDomainCount')]"
-                    },
                     "storageSettings": {
                         "value": "[variables('dataNodeStorageSettings')]"
                     },
@@ -433,6 +424,9 @@
                     },
                     "namespace": {
                         "value": "data"
+                    },
+                    "networkSettings": {
+                        "value": "[variables('networkSettings')]"
                     },
                     "osSettings": {
                         "value": "[variables('osSettings')]"

--- a/src/mainTemplate.json
+++ b/src/mainTemplate.json
@@ -271,9 +271,9 @@
             }
         },
         "platformFaultDomainCount": "[if(contains(variables('locations'), variables('location')), variables('locations')[variables('location')].platformFaultDomainCount, 2)]",
-        "metaNodesIpPrefix": "10.0.0.1",
-        "dataNodesIpPrefix": "10.0.1.1",
         "networkSettings": {
+            "metaNodesIpPrefix": "10.0.0.1",
+            "dataNodesIpPrefix": "10.0.1.1",
             "virtualNetworkName": "[parameters('virtualNetworkName')]",
             "addressPrefix": "10.0.0.0/16",
             "subnet": {
@@ -346,8 +346,8 @@
                     "password": {
                         "value": "[variables('password')]"
                     },
-                    "metaNodesIpPrefix": {
-                        "value": "[variables('metaNodesIpPrefix')]"
+                    "networkSettings": {
+                        "value": "[variables('networkSettings')]"
                     },
                     "location": {
                         "value": "[variables('location')]"
@@ -360,9 +360,6 @@
                     },
                     "namespace": {
                         "value": "meta"
-                    },
-                    "subnet": {
-                        "value": "[variables('networkSettings').subnet.meta]"
                     },
                     "osSettings": {
                         "value": "[variables('osSettings')]"
@@ -416,20 +413,17 @@
                     "password": {
                         "value": "[variables('password')]"
                     },
-                    "dataNodesIpPrefix": {
-                        "value": "[variables('dataNodesIpPrefix')]"
-                    },
                     "location": {
                         "value": "[variables('location')]"
+                    },
+                    "networkSettings": {
+                        "value": "[variables('networkSettings')]"
                     },
                     "platformFaultDomainCount": {
                         "value": "[variables('platformFaultDomainCount')]"
                     },
                     "storageSettings": {
                         "value": "[variables('dataNodeStorageSettings')]"
-                    },
-                    "subnet": {
-                        "value": "[variables('networkSettings').subnet.data]"
                     },
                     "vmSize": {
                         "value": "[parameters('vmSizeDataNodes')]"

--- a/src/mainTemplate.json
+++ b/src/mainTemplate.json
@@ -45,7 +45,18 @@
                 "No"
             ],
             "metadata": {
-                "description": "Provision a machine with Chronograf on it"
+                "description": "Provision a single instance with Chronograf service installed."
+            }
+        },
+        "monitor": {
+            "type": "string",
+            "defaultValue": "No",
+            "allowedValues": [
+                "Yes",
+                "No"
+            ],
+            "metadata": {
+                "description": "Provision a single instance with InfluxDB-OSS service installed."
             }
         },
         "vmDataDiskSize": {
@@ -121,13 +132,13 @@
                 "Standard_D5_v2"
             ],
             "metadata": {
-                "description": "Size of the InfluxEnterprise meta nodes, 3 of these will be provisioned"
+                "description": "Size of the InfluxEnterprise meta nodes, 3 instances will be provisioned"
             }
         },
         "adminUsername": {
             "type": "string",
             "metadata": {
-                "description": "Admin username used when provisioning virtual machines"
+                "description": "Admin username used when provisioning all virtual machines"
             }
         },
         "password": {
@@ -139,13 +150,13 @@
         "influxdbUsername": {
             "type": "string",
             "metadata": {
-                "description": "Database username for admin user with ALL PRIVILEGES"
+                "description": "InfluxDB Enterpise username for admin user with ALL PRIVILEGES"
             }
         },
         "influxdbPassword": {
             "type": "securestring",
             "metadata": {
-                "description": "Database password for admin user with ALL PRIVILEGES"
+                "description": "InfluxDB Enterpise password for admin user with ALL PRIVILEGES"
             }
         },
         "location": {
@@ -171,12 +182,15 @@
         },
         "location": "[parameters('location')]",
         "chronoScriptUrl": "[uri(parameters('_artifactsLocation'), concat('scripts/chronograf-install.sh', parameters('_artifactsLocationSasToken')))]",
-        "clusterScriptUrl": "[uri(parameters('_artifactsLocation'), concat('scripts/cluster-configure.sh', parameters('_artifactsLocationSasToken')))]",
+        "influxdbScriptUrl": "[uri(parameters('_artifactsLocation'), concat('scripts/influxdb-install.sh', parameters('_artifactsLocationSasToken')))]",
+        "enterpriseScriptUrl": "[uri(parameters('_artifactsLocation'), concat('scripts/enterprise-configure.sh', parameters('_artifactsLocationSasToken')))]",
         "diskScriptUrl": "[uri(parameters('_artifactsLocation'), concat('scripts/autopart.sh', parameters('_artifactsLocationSasToken')))]",
         "sharedTemplateUrl": "[uri(parameters('_artifactsLocation'), concat('partials/shared-resources.json', parameters('_artifactsLocationSasToken')))]",
         "metaTemplateUrl": "[uri(parameters('_artifactsLocation'), concat('machines/metanodes-resources.json', parameters('_artifactsLocationSasToken')))]",
         "chronografTemplateUrl": "[uri(parameters('_artifactsLocation'), concat('machines/chronograf-resources.json', parameters('_artifactsLocationSasToken')))]",
-        "commonInstallParams": "[concat(' -c ', parameters('vmDataNodeCount'), ' -u ', parameters('influxdbUsername'), ' -p ', parameters('influxdbPassword'))]",
+        "monitorTemplateUrl": "[uri(parameters('_artifactsLocation'), concat('machines/monitor-resources.json', parameters('_artifactsLocationSasToken')))]",
+        "commonInstallParams": "[concat(' -u ', parameters('influxdbUsername'), ' -p ', parameters('influxdbPassword'))]",
+        "clusterInstallParams": "[concat(' -c ', parameters('vmDataNodeCount'), ' -m ', parameters('monitor'))]",
         "osSettings": {
             "imageReference": {
                 "publisher": "Canonical",
@@ -189,7 +203,7 @@
             "vmSizeMetaNodes": "[parameters('vmSizeMetaNodes')]",
             "vmDataNodeCount": "[parameters('vmDataNodeCount')]",
             "influxTags": "[parameters('influxTags')]",
-            "chronoSize": "Standard_D2_v2",
+            "vmDefaultSize": "Standard_DS2_v2",
             "extensionSettings": {
                 "meta": {
                     "publisher": "Microsoft.Azure.Extensions",
@@ -199,9 +213,9 @@
                     "settings": {
                         "fileUris": [
                             "[variables('diskScriptUrl')]",
-                            "[variables('clusterScriptUrl')]"
+                            "[variables('enterpriseScriptUrl')]"
                         ],
-                        "commandToExecute": "[concat('bash cluster-configure.sh -n meta', variables('commonInstallParams'))]"
+                        "commandToExecute": "[concat('bash enterprise-configure.sh -s meta', variables('clusterInstallParams'), variables('commonInstallParams'))]"
                     }
                 },
                 "data": {
@@ -212,12 +226,12 @@
                     "settings": {
                         "fileUris": [
                             "[variables('diskScriptUrl')]",
-                            "[variables('clusterScriptUrl')]"
+                            "[variables('enterpriseScriptUrl')]"
                         ],
-                        "commandToExecute": "[concat('bash cluster-configure.sh -n data', variables('commonInstallParams'))]"
+                        "commandToExecute": "[concat('bash enterprise-configure.sh -s data', variables('clusterInstallParams'), variables('commonInstallParams'))]"
                     }
                 },
-                "master": {
+                "leader": {
                     "publisher": "Microsoft.Azure.Extensions",
                     "type": "CustomScript",
                     "typeHandlerVersion": "2.0",
@@ -225,9 +239,9 @@
                     "settings": {
                         "fileUris": [
                             "[variables('diskScriptUrl')]",
-                            "[variables('clusterScriptUrl')]"
+                            "[variables('enterpriseScriptUrl')]"
                         ],
-                        "commandToExecute": "[concat('bash cluster-configure.sh -n master', variables('commonInstallParams'))]"
+                        "commandToExecute": "[concat('bash enterprise-configure.sh -s leader', variables('clusterInstallParams'), variables('commonInstallParams'))]"
                     }
                 },
                 "chronograf": {
@@ -240,6 +254,18 @@
                             "[variables('chronoScriptUrl')]"
                         ],
                         "commandToExecute": "bash chronograf-install.sh"
+                    }
+                },
+                "monitor": {
+                    "publisher": "Microsoft.Azure.Extensions",
+                    "type": "CustomScript",
+                    "typeHandlerVersion": "2.0",
+                    "autoUpgradeMinorVersion": true,
+                    "settings": {
+                        "fileUris": [
+                            "[variables('influxdbScriptUrl')]"
+                        ],
+                        "commandToExecute": "[concat('bash influxdb-install.sh', variables('commonInstallParams'))]"
                     }
                 }
             }
@@ -455,6 +481,45 @@
                     },
                     "location": {
                         "value": "[variables('location')]"
+                    },
+                    "namespace": {
+                        "value": "chronograf"
+                    },
+                    "networkSettings": {
+                        "value": "[variables('networkSettings')]"
+                    },
+                    "osSettings": {
+                        "value": "[variables('osSettings')]"
+                    }
+                }
+            }
+        },
+        {
+            "condition": "[equals(parameters('monitor'), 'Yes')]",
+            "name": "monitor",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2019-08-01",
+            "dependsOn": [
+                "[concat('Microsoft.Resources/deployments/', 'shared')]"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[variables('monitorTemplateUrl')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "adminUsername": {
+                        "value": "[parameters('adminUsername')]"
+                    },
+                    "password": {
+                        "value": "[variables('password')]"
+                    },
+                    "location": {
+                        "value": "[variables('location')]"
+                    },
+                    "namespace": {
+                        "value": "monitor"
                     },
                     "networkSettings": {
                         "value": "[variables('networkSettings')]"

--- a/src/mainTemplate.json
+++ b/src/mainTemplate.json
@@ -169,6 +169,7 @@
             "authenticationType": "[parameters('password').authenticationType]",
             "sshPublicKey": "[if(equals(parameters('password').authenticationType,'sshPublicKey'),parameters('password').sshPublicKey,json('null'))]"
         },
+        "location": "[parameters('location')]",
         "chronoScriptUrl": "[uri(parameters('_artifactsLocation'), concat('scripts/chronograf-install.sh', parameters('_artifactsLocationSasToken')))]",
         "clusterScriptUrl": "[uri(parameters('_artifactsLocation'), concat('scripts/cluster-configure.sh', parameters('_artifactsLocationSasToken')))]",
         "diskScriptUrl": "[uri(parameters('_artifactsLocation'), concat('scripts/autopart.sh', parameters('_artifactsLocationSasToken')))]",
@@ -183,6 +184,7 @@
                 "sku": "18.04-LTS",
                 "version": "latest"
             },
+            "influxTags": "[parameters('influxTags')]",
             "managementPort": "22",
             "chronoSize": "Standard_D2_v2",
             "extensionSettings": {
@@ -239,7 +241,36 @@
                 }
             }
         },
-        "location": "[parameters('location')]",
+        "locations": {
+            "eastus": {
+                "platformFaultDomainCount": 3
+            },
+            "eastus2": {
+                "platformFaultDomainCount": 3
+            },
+            "centralus": {
+                "platformFaultDomainCount": 3
+            },
+            "northcentralus": {
+                "platformFaultDomainCount": 3
+            },
+            "southcentralus": {
+                "platformFaultDomainCount": 3
+            },
+            "westus": {
+                "platformFaultDomainCount": 3
+            },
+            "canadacentral": {
+                "platformFaultDomainCount": 3
+            },
+            "northeurope": {
+                "platformFaultDomainCount": 3
+            },
+            "westeurope": {
+                "platformFaultDomainCount": 3
+            }
+        },
+        "platformFaultDomainCount": "[if(contains(variables('locations'), variables('location')), variables('locations')[variables('location')].platformFaultDomainCount, 2)]",
         "metaNodesIpPrefix": "10.0.0.1",
         "dataNodesIpPrefix": "10.0.1.1",
         "networkSettings": {
@@ -289,7 +320,8 @@
                 "template": {
                     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
-                    "resources": []
+                    "resources": [
+                    ]
                 }
             }
         },
@@ -320,8 +352,8 @@
                     "location": {
                         "value": "[variables('location')]"
                     },
-                    "influxTags": {
-                        "value": "[parameters('influxTags')]"
+                    "platformFaultDomainCount": {
+                        "value": "[variables('platformFaultDomainCount')]"
                     },
                     "vmSize": {
                         "value": "[parameters('vmSizeMetaNodes')]"
@@ -390,8 +422,8 @@
                     "location": {
                         "value": "[variables('location')]"
                     },
-                    "influxTags": {
-                        "value": "[parameters('influxTags')]"
+                    "platformFaultDomainCount": {
+                        "value": "[variables('platformFaultDomainCount')]"
                     },
                     "storageSettings": {
                         "value": "[variables('dataNodeStorageSettings')]"
@@ -434,9 +466,6 @@
                 "parameters": {
                     "adminUsername": {
                         "value": "[parameters('adminUsername')]"
-                    },
-                    "influxTags": {
-                        "value": "[parameters('influxTags')]"
                     },
                     "password": {
                         "value": "[variables('password')]"

--- a/src/mainTemplate.json
+++ b/src/mainTemplate.json
@@ -417,9 +417,6 @@
                     "storageSettings": {
                         "value": "[variables('dataNodeStorageSettings')]"
                     },
-                    "vmCount": {
-                        "value": "[parameters('vmDataNodeCount')]"
-                    },
                     "namespace": {
                         "value": "data"
                     },
@@ -459,8 +456,8 @@
                     "location": {
                         "value": "[variables('location')]"
                     },
-                    "subnet": {
-                        "value": "[variables('networkSettings').subnet.data]"
+                    "networkSettings": {
+                        "value": "[variables('networkSettings')]"
                     },
                     "osSettings": {
                         "value": "[variables('osSettings')]"

--- a/src/mainTemplate.json
+++ b/src/mainTemplate.json
@@ -353,9 +353,6 @@
                     "location": {
                         "value": "[variables('location')]"
                     },
-                    "vmSize": {
-                        "value": "[parameters('vmSizeMetaNodes')]"
-                    },
                     "namespace": {
                         "value": "meta"
                     },

--- a/src/mainTemplate.json
+++ b/src/mainTemplate.json
@@ -184,8 +184,11 @@
                 "sku": "18.04-LTS",
                 "version": "latest"
             },
+
+            "vmSizeDataNodes": "[parameters('vmSizeDataNodes')]",
+            "vmSizeMetaNodes": "[parameters('vmSizeMetaNodes')]",
+            "vmDataNodeCount": "[parameters('vmDataNodeCount')]",
             "influxTags": "[parameters('influxTags')]",
-            "managementPort": "22",
             "chronoSize": "Standard_D2_v2",
             "extensionSettings": {
                 "meta": {
@@ -274,6 +277,7 @@
             "platformFaultDomainCount": "[if(contains(variables('locations'), variables('location')), variables('locations')[variables('location')].platformFaultDomainCount, 2)]",
             "metaNodesIpPrefix": "10.0.0.1",
             "dataNodesIpPrefix": "10.0.1.1",
+            "managementPort": "22",
             "virtualNetworkName": "[parameters('virtualNetworkName')]",
             "addressPrefix": "10.0.0.0/16",
             "subnet": {
@@ -415,9 +419,6 @@
                     },
                     "storageSettings": {
                         "value": "[variables('dataNodeStorageSettings')]"
-                    },
-                    "vmSize": {
-                        "value": "[parameters('vmSizeDataNodes')]"
                     },
                     "vmCount": {
                         "value": "[parameters('vmDataNodeCount')]"

--- a/src/scripts/chronograf-install.sh
+++ b/src/scripts/chronograf-install.sh
@@ -51,8 +51,7 @@ install_chronograf()
     local PACKAGE="chronograf_${CHRONOGRAF_VERSION}_amd64.deb"
     local DOWNLOAD_URL="https://dl.influxdata.com/chronograf/releases/chronograf_${CHRONOGRAF_VERSION}_amd64.deb"
 
-    log "[install_chronograf] download Chronograf $CHRONOGRAF_VERSION"
-    log "[install_chronograf] download location $DOWNLOAD_URL"
+    log "[download_chronograf] downloading Chronograf from location $DOWNLOAD_URL"
 
     wget --retry-connrefused --waitretry=1 -q "$DOWNLOAD_URL" -O $PACKAGE
     EXIT_CODE=$?
@@ -60,25 +59,15 @@ install_chronograf()
         log "err: downloading Chronograf $CHRONOGRAF_VERSION..."
         exit $EXIT_CODE
     fi
-    log "[install_chronograf] downloaded Chronograf $CHRONOGRAF_VERSION"
 
     log "[install_chronorgaf] installing Chronorgaf $CHRONOGRAF_VERSION"
     dpkg -i $PACKAGE
-    log "[install_chronograf] installed Chronograf $CHRONOGRAF_VERSION"
 }
-
-configure_systemd()
-{
-    log "[configure_systemd] configure systemd to start Chronograf service automatically when system boots"
-    systemctl daemon-reload
-    systemctl enable chronograf.service
-}
-
 start_systemd()
 {
     log "[start_systemd] starting Chronorgaf"
     systemctl start chronograf.service
-    log "[start_systemd] started Chronograf"
+    sleep 5
 }
 
 #########################
@@ -96,8 +85,6 @@ fi
 log "[apt-get] updated apt-get"
 
 install_chronograf
-
-configure_systemd
 
 start_systemd
 

--- a/src/scripts/chronograf-install.sh
+++ b/src/scripts/chronograf-install.sh
@@ -40,7 +40,7 @@ fi
 #########################
 
 #Script Parameters
-CHRONOGRAF_VERSION="1.8.3"
+CHRONOGRAF_VERSION="1.8.4"
 
 #########################
 # Installation func

--- a/src/scripts/cluster-configure.sh
+++ b/src/scripts/cluster-configure.sh
@@ -90,46 +90,6 @@ done
 # Configuration functions
 #########################
 
-setup_metanodes()
-{
-  # TEMP-SOLUTION: Hard coded privateIP's
-  # Append metanode vm hostname  to the hsots file
-
-  log "[setup_metanodes] adding all metanodes to the /etc/hosts file"
-  if [ -n "$(grep ${HOSTNAME} /etc/hosts)" ]
-    then
-      log "[setup_metanodes] hostname already exists : $(grep $HOSTNAME $ETC_HOSTS)"
-    else
-        for i in $(seq 0 2); do 
-          echo "10.0.0.1${i} vmmeta-${i}" >> /etc/hosts
-        done        
-  fi
-}
-
-setup_datanodes()
-{
-  # TEMP-SOLUTION: Hard coded privateIP's
-  # Append metanode vm hostname  to the hsots file
-
-  if [ -z "${COUNT}" ]; then
-    log  "err: missing datanode count parameter..."
-    exit 2
-  fi
-
-  END=`expr ${COUNT} - 1`
-
-  log "[setup_datanodes] adding all datanodes to the /etc/hosts file"
-
-  if [ -n "$(grep ${HOSTNAME} /etc/hosts)" ]
-    then
-      log "[setup_datanodes] hostname already exists : $(grep $HOSTNAME $ETC_HOSTS)"
-    else
-        for i in $(seq 0 "${END}"); do 
-          echo "10.0.1.1${i} vmdata-${i}" >> /etc/hosts
-        done        
-  fi
-}
-
 join_metanodes()
 {
   #joining meatanodes
@@ -318,10 +278,9 @@ if [[ $EXIT_CODE -ne 0 ]]; then
   log "[apt-get] failed updating apt-get. exit code: $EXIT_CODE"
   exit $EXIT_CODE
 fi
-log "[apt-get] updated apt-get"
 
 
-#format data disk (Find data disks then partition, format, and mount it
+# format data disk (Find data disks then partition, format, and mount it
 # as seperate drive under /influxdb/* )_
 #------------------------
 log "[autopart] running auto partitioning & mounting"
@@ -332,16 +291,12 @@ bash autopart.sh
 if [[ ${NODE_TYPE} == "meta" ]] || [[ ${NODE_TYPE} == "master" ]]; then
     log "[metanode_funcs] executing metanode configuration functions"
 
-   # setup_metanodes
-
     configure_metanodes
 
 elif [[ ${NODE_TYPE} == "data" ]]; then
     log "[datanode_funcs] executing datanode configuration functions"
     
     datanode_count
-
-  #  setup_datanodes
 
     configure_datanodes
 else 

--- a/src/scripts/cluster-configure.sh
+++ b/src/scripts/cluster-configure.sh
@@ -332,7 +332,7 @@ bash autopart.sh
 if [[ ${NODE_TYPE} == "meta" ]] || [[ ${NODE_TYPE} == "master" ]]; then
     log "[metanode_funcs] executing metanode configuration functions"
 
-    setup_metanodes
+   # setup_metanodes
 
     configure_metanodes
 
@@ -341,7 +341,7 @@ elif [[ ${NODE_TYPE} == "data" ]]; then
     
     datanode_count
 
-    setup_datanodes
+  #  setup_datanodes
 
     configure_datanodes
 else 

--- a/src/scripts/enterprise-configure.sh
+++ b/src/scripts/enterprise-configure.sh
@@ -13,10 +13,11 @@ help()
     echo " "
     echo "This script configures a new InfluxEnterpise cluster deployed with Azure ARM templates."
     echo "Parameters:"
-    echo "-n  Configure specific node_type [meta || data || master]"
-    echo "-u  Supply influxdb admin username  cluster nodes - used in case of [master] node only"
-    echo "-p  Supply influxdb admin password  cluster nodes - used in case of [master] node only"
-    echo "-c  Number of datanodes to configure - used in case of [data||master] node configurations"
+    echo "-s  Configure specific enterprise service [meta || data || leader]"
+    echo "-c  Number of datanodes to configure - used by [leader] service"
+    echo "-m  Monitor instance enabled, if [Yes] then start Telegraf services"
+    echo "-u  Supply influxdb admin username enterprise  - used by [leader] service only"
+    echo "-p  Supply influxdb admin password enterprise  - used by [leader] service only"
     echo "-h  view this help content"
 }
 
@@ -29,13 +30,12 @@ help()
 log()
 {
      echo \[$(date +%d%m%Y-%H:%M:%S)\] "$1"
-     echo \[$(date +%d%m%Y-%H:%M:%S)\] "$1" >> /var/log/cluster-configuration.log
+     echo \[$(date +%d%m%Y-%H:%M:%S)\] "$1" >> /var/log/enterprise-configuration.log
 }
 
 
-log "Begin execution of Cluster Configuration script extension on ${HOSTNAME}"
+log "Begin execution of Enterpise Cluster script extension on ${HOSTNAME}"
 START_TIME=$SECONDS
-
 
 #########################
 # Check user access
@@ -55,23 +55,25 @@ META_CONFIG_FILE="/etc/influxdb/influxdb-meta.conf"
 DATA_CONFIG_FILE="/etc/influxdb/influxdb.conf"
 META_ENV_FILE="/etc/default/influxdb-meta"
 DATA_ENV_FILE="/etc/default/influxdb"
-ETC_HOSTS="/etc/hosts"
-
+TELEGRAF_CONFIG_FILE="/etc/telegraf/telegraf.conf"
 
 #Loop through options passed
-while getopts :n:c:u:p:h optname; do
+while getopts :s:c:m:u:p:h optname; do
   log "Option $optname set"
   case $optname in
-    n)  #configure [meta||data||master] nodes
-      NODE_TYPE="${OPTARG}"
+    s)  #configure specific service [meta||data||leader]
+      SERVICE="${OPTARG}"
       ;;
-    c) #number os datanodes - used in case of [data||master] nodes configurations
+    c) #number of os datanodes - used by [leader] service only
       COUNT="${OPTARG}"
       ;;
-    u) #influxdb admin username - used in case of [master] node configurations only
+    m) #monitor instance enabled, if [Yes] then start telegraf services
+      MONITOR="${OPTARG}"
+      ;;
+    u) #influxdb admin username - used by [leader] service only
       INFLUXDB_USER="${OPTARG}"
       ;;
-    p) #influxdb admin password - used in case of [master] node configurations only
+    p) #influxdb admin password - used by [leader] service only
       INFLUXDB_PWD="${OPTARG}"
       ;;
     h) #show help
@@ -124,9 +126,6 @@ configure_metanodes()
       exit $EXIT_CODE
     fi
     
-    #need to update the influxdb-meta.conf default values
-    log  "[sed_cmd] updated ${META_CONFIG_FILE} default file values"
-
     chown influxdb:influxdb "${META_CONFIG_FILE}"
 
     #create etc/default/influxdb file to over-ride configuration defaults
@@ -153,6 +152,9 @@ EOF
      log  "err: creating file ${META_GEN_FILE}. you will need to manually configure the metanode"
      exit 1
   fi
+
+  start_service influxdb-meta 
+
 }
 
 configure_datanodes()
@@ -169,9 +171,6 @@ configure_datanodes()
        log "err: could not copy new ${DATA_GEN_FILE} file to /etc/influxdb"
       exit $EXIT_CODE
     fi
-
-    #need to update the influxdb.conf default values
-    log  "[sed_cmd] updated ${META_CONFIG_FILE} default file values"
 
     chown influxdb:influxdb "${DATA_CONFIG_FILE}"
 
@@ -208,6 +207,7 @@ EOF
      log  "err: creating file ${DATA_GEN_FILE}. you will need to manually configure the metanode"
      exit 1
   fi
+  start_service influxdb 
 }
 datanode_count()
 {
@@ -215,48 +215,82 @@ datanode_count()
   log "[datanode_count] checking COUNT parameter"
 
   if [ -z "${COUNT}" ]; then
-    log "err: please set \$_COUNT parameter..."
+    log "err: datanode count not set - please set -c parameter."
 
     exit 1
   fi
 }
-
-start_systemd()
+telegraf()
 {
-  if [[ ${NODE_TYPE} == "meta" ]] || [[ ${NODE_TYPE} == "master" ]]; then
-    log "[start_systemd] starting metanode"
-    systemctl start influxdb-meta
+  #generate and stage new telegraf configuration file
+  log "[configure_telegraf] generating new telegraf configuration file at ${TELEGRAF_CONFIG_FILE}"
+
+    touch "${TELEGRAF_CONFIG_FILE}"
+    if [ $? -eq 0 ]; then
+      cat > "${TELEGRAF_CONFIG_FILE}" <<-EOF
+      #Global Agent Configuration
+          [agent]
+            hostname = "${HOSTNAME}"
+
+          # Input Plugins
+          [[inputs.cpu]]
+              percpu = true
+              totalcpu = true
+              collect_cpu_time = false
+              report_active = false
+          [[inputs.disk]]
+              ignore_fs = ["tmpfs", "devtmpfs", "devfs"]
+          [[inputs.diskio]]
+          [[inputs.mem]]
+          [[inputs.net]]
+          [[inputs.system]]
+          [[inputs.swap]]
+          [[inputs.netstat]]
+          [[inputs.processes]]
+
+          # Output Plugin InfluxDB
+          [[outputs.influxdb]]
+            database = "telegraf"
+            urls = [ "http://vmmonitor:8086" ]
+            username = "${INFLUXDB_USER}"
+            password = "${INFLUXDB_PWD}"
+EOF
+    else
+      log  "err: cannot create /etc/telegraf/telegraf.conf file. you will need to manually configure telegraf"
+      exit 1
+    fi
+    
+    chown telegraf:telegraf "${TELEGRAF_CONFIG_FILE}"
+
+    start_service telegraf 
+}
+start_service()
+{
+   # s stores $1 service argument passed to start_service()
+   s=$1
+    #start service 
+    systemctl start ${s}
     sleep 5
-  elif [[ ${NODE_TYPE} == "data" ]]; then
-    log "[start_systemd] starting datanode"
-    systemctl start influxdb
-    sleep 5
-  fi
+
+    if (systemctl -q is-active ${s}); then 
+      log "info: ${s} service running."
+    else
+      log "err:  ${s} service did not start, please check and restart manually."
+      exit 1
+    fi
 }
 
 create_user()
 {
-#check service status
-log "[create_user] create influxdb admin user"
-
-payload="q=CREATE USER ${INFLUXDB_USER} WITH PASSWORD '${INFLUXDB_PWD}' WITH ALL PRIVILEGES"
-
-curl -s -k -X POST \
-    -d "${payload}" \
-    "http://vmdata-0:8086/query"
-    
-}
-process_check()
-{
   #check service status
-  log "[process_check] check service process started"
+  log "[create_user] create influxdb admin user"
 
-  PROC_CHECK=`ps aux | grep -v grep | grep influxdb`
-  EXIT_CODE=$?
-  if [[ $EXIT_CODE -ne 0 ]]; then
-    log "err: could not start influxdb service, try starting manually."
-    exit $EXIT_CODE
-  fi
+  payload="q=CREATE USER ${INFLUXDB_USER} WITH PASSWORD '${INFLUXDB_PWD}' WITH ALL PRIVILEGES"
+
+  curl -s -k -X POST \
+      -d "${payload}" \
+      "http://vmdata-0:8086/query"
+      
 }
 
 install_ntp()
@@ -284,40 +318,34 @@ fi
 # as seperate drive under /influxdb/* )_
 #------------------------
 log "[autopart] running auto partitioning & mounting"
-
 bash autopart.sh
 
 
-if [[ ${NODE_TYPE} == "meta" ]] || [[ ${NODE_TYPE} == "master" ]]; then
-    log "[metanode_funcs] executing metanode configuration functions"
-
+if [[ ${SERVICE} == "meta" ]] || [[ ${SERVICE} == "leader" ]]; then
+    log "[metanode_service] executing metanode configuration functions"
     configure_metanodes
-
-elif [[ ${NODE_TYPE} == "data" ]]; then
-    log "[datanode_funcs] executing datanode configuration functions"
-    
-    datanode_count
-
+elif [[ ${SERVICE} == "data" ]]; then
+    log "[datanode_service] executing datanode configuration functions"
     configure_datanodes
 else 
-    log "err: node_type unknown, please set a valid node_type"
+    log "err: service type unknown, please set a valid service"
 
     help
     exit 2
 fi
 
-
-#start service & check process
+#start telegraf service
 #------------------------
-start_systemd
 
-process_check
+if [[ ${MONITOR} == "Yes" ]]; then
+    log "infor: monitoring instance configured, enabling Telegraf services on host"
+    telegraf
+fi
 
-
-#master metanode funcs to join all nodes to cluster 
+#leader service to join all nodes to cluster 
 #------------------------
-if [[ ${NODE_TYPE} == "master" ]];then
-  log "[master_metanode] executing cluster join commands on master metanode"
+if [[ ${SERVICE} == "leader" ]];then
+  log "[leader_service] executing cluster join commands on leader metanode"
 
   datanode_count
 

--- a/src/scripts/influxdb-install.sh
+++ b/src/scripts/influxdb-install.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+# License: https://github.com/influxdata/azure-resource-manager-influxdb-enterprise/blob/master/LICENSE
+#
+# Install IndluxDB OSS  ARM template cluster
+#
+# 06/2020 Initial Version
+#--------------------------
+
+help()
+{
+    echo " "
+    echo "This script configures a new InfluxDB OSS node for monitoring the enterprise cluster deployed with Azure ARM templates."
+    echo "Parameters:"
+    echo "-u  influxdb admin username"
+    echo "-p  influxdb admin password"
+    echo "-h  view this help content"
+}
+
+#########################
+# Logging func
+#########################
+
+# Custom logging with time so we can easily relate running times, also log to separate file so order is guaranteed.
+# The Script extension output the stdout/err buffer in intervals with duplicates.
+
+log()
+{
+
+     echo \[$(date +%d%m%Y-%H:%M:%S)\] "$1"
+     echo \[$(date +%d%m%Y-%H:%M:%S)\] "$1" >> /var/log/oss-install.log
+}
+
+log "Begin execution of InfluxDB OSS script extension on ${HOSTNAME}"
+START_TIME=$SECONDS
+
+#########################
+# Check user access
+#########################
+
+if [ "${UID}" -ne 0 ];
+then
+    log "Script executed without root permissions"
+    echo "You must be root to run this program." >&2
+    exit 3
+fi
+
+#Loop through options passed
+while getopts :u:p:h optname; do
+  log "Option $optname set"
+  case $optname in
+    u) #influxdb admin username
+      INFLUXDB_USER="${OPTARG}"
+      ;;
+    p) #influxdb admin password
+      INFLUXDB_PWD="${OPTARG}"
+      ;;
+    h) #show help
+      help
+      exit 2
+      ;;
+    \?) #unrecognized option - show help
+      echo -e \\n"Option -${BOLD}$OPTARG${NORM} not allowed."
+      help
+      exit 2
+      ;;
+  esac
+done
+
+#########################
+# Parameter handling
+#########################
+
+#Script Parameters
+OSS_VERSION="1.8.0"
+
+#########################
+# Installation 
+#########################
+
+install_influxdb()
+{
+    local PACKAGE="influxdb_${OSS_VERSION}_amd64.deb"
+    local DOWNLOAD_URL="https://dl.influxdata.com/influxdb/releases/influxdb_${OSS_VERSION}_amd64.deb"
+
+    log "[download_oss] download InfluxDB OSS from location $DOWNLOAD_URL"
+
+    wget --retry-connrefused --waitretry=1 -q "$DOWNLOAD_URL" -O $PACKAGE
+    EXIT_CODE=$?
+    if [[ $EXIT_CODE -ne 0 ]]; then
+        log "err: downloading InfluxDB $OSS_VERSION"
+        exit $EXIT_CODE
+    fi
+
+    log "[install_oss] installing InfluxDB $OSS_VERSION"
+    dpkg -i $PACKAGE
+
+    #create etc/default/influxdb file to over-ride configuration defaults
+    touch "/etc/default/influxdb"
+    if [ $? -eq 0 ]; then
+      cat > "/etc/default/influxdb" <<-EOF
+        INFLUXDB_HTTP_AUTH_ENABLED="true"
+        INFLUXDB_DATA_INDEX_VERSION="tsi1"
+        INFLUXDB_HTTP_FLUX_ENABLED="true"
+EOF
+    else
+      log  "err: cannot create /etc/default/influxdb file. you will need to manually configure the datanode"
+      exit 1
+    fi
+}
+create_user()
+{
+    #check service status
+    log "[create_user] create oss admin user"
+    payload="q=CREATE USER ${INFLUXDB_USER} WITH PASSWORD '${INFLUXDB_PWD}' WITH ALL PRIVILEGES"
+
+    curl -s -k -X POST \
+        -d "${payload}" \
+        "http://vmmonitor:8086/query"
+}
+start_systemd()
+{
+    log "[start_systemd] starting InfluxDB"
+    systemctl start influxdb.service
+    sleep 10
+}
+
+#########################
+# Primary Install Tasks
+#########################
+
+
+log "[apt-get] updating apt-get"
+(apt-get -y update || (sleep 15; apt-get -y update))
+EXIT_CODE=$?
+if [[ $EXIT_CODE -ne 0 ]]; then
+  log "[apt-get] failed updating apt-get. exit code: $EXIT_CODE"
+  exit $EXIT_CODE
+fi
+log "[apt-get] updated apt-get"
+
+install_influxdb
+
+start_systemd
+
+create_user
+
+ELAPSED_TIME=$(($SECONDS - $START_TIME))
+PRETTY=$(printf '%dh:%dm:%ds\n' $(($ELAPSED_TIME/3600)) $(($ELAPSED_TIME%3600/60)) $(($ELAPSED_TIME%60)))
+log "End execution of InfluxDB script extension in ${PRETTY}"


### PR DESCRIPTION
This PR addresses bug fixes for regions with limited fault domains and adds new feature for including a new monitoring instance as part of the enterprise cluster deployment.

Adding a new monitoring instances does the following:
- download and install single node OSS  instances 
- configure and enable Telegraf services on all enterprise instances 
- start Telegraf collection into OSS instance 
